### PR TITLE
Convert Ollama model response to list correctly, and ignore API Key r…

### DIFF
--- a/llm_integration.py
+++ b/llm_integration.py
@@ -63,7 +63,7 @@ def send_prompt_to_llm(final_prompt, overrides=None, conversation_history=None):
     print(f"🔍 DEBUG: API Key Retrieved = '{api_key}' (length: {len(api_key)})")
 
     # Skip the API key check if using a local provider
-    if provider != "Local" and not api_key:
+    if provider not in ["Local", "Ollama"] and not api_key:
         print("❌ ERROR: API Key is missing or empty! Check settings.json.")
         return "[Error: Missing API Key]"
 

--- a/model_fetcher.py
+++ b/model_fetcher.py
@@ -155,8 +155,8 @@ class ModelFetcher(QObject):
             response = requests.get(models_endpoint, timeout=10)
             if response.status_code == 200:
                 models_data = response.json()
-                if isinstance(models_data, dict) and "models" in models_data:
-                    model_list = models_data["models"]
+                if isinstance(models_data, dict) and "data" in models_data:
+                    model_list = [model["id"] for model in models_data["data"]]
                 elif isinstance(models_data, list):
                     model_list = models_data
                 else:


### PR DESCRIPTION
Quick fix to handle the Ollama model list response correctly, and to add Ollama to the list of models that do not require an api_key. A better fix would be to add a checkbox to the setup configuration, "Requires API Key:" and look for that flag in the provider config settings, but I'm in the process of redesigning the config settings so I'll incorporate that later.