### PR TITLE
Fix Ollama Test and remove hardcoded endpoints in llm_integration

### DIFF
--- a/options.py
+++ b/options.py
@@ -96,7 +96,7 @@ class ProviderConfigWidget(QWidget):
         
         # For OpenRouter, test using the models endpoint.
         test_url = url
-        if provider == "OpenRouter":
+        if provider in ["OpenRouter", "Ollama"]:
             test_url = url.replace("/chat/completions", "/models")
             headers["HTTP-Referer"] = "http://localhost:1234"
         


### PR DESCRIPTION
Ollama needs the same substitution that OpenRouter uses for its test. I also noticed that llm_integration had hard coded the endpoint URLs so that the user could not change them in the options, so I modified llm_integration.py to retrieve the endpoint URL from the settings.json file instead.