### PR TITLE
Fix for Mac to use MacOS native say() command as a subprocess

### DIFF
--- a/project_window_core.py
+++ b/project_window_core.py
@@ -20,7 +20,7 @@ from summary_feature import create_summary as create_summary_feature
 from prompts import load_project_options
 from tree_manager import load_structure, save_structure, populate_tree, update_structure_from_tree, delete_node
 from context_panel import ContextPanel
-import tts_manager
+from tts_manager import WW_TTSManager
 import autosave_manager
 from dialogs import CreateSummaryDialog
 from project_ui import build_main_ui
@@ -791,7 +791,7 @@ class ProjectWindow(QMainWindow):
 
     def toggle_tts(self):
         if self.tts_playing:
-            tts_manager.stop()
+            WW_TTSManager.stop()
             self.tts_playing = False
             self.tts_action.setIcon(QIcon("assets/icons/play-circle.svg"))
         else:
@@ -807,19 +807,21 @@ class ProjectWindow(QMainWindow):
                 return
             self.tts_playing = True
             self.tts_action.setIcon(QIcon("assets/icons/stop-circle.svg"))
-            def run_speech():
-                try:
-                    tts_manager.speak(
-                        text,
-                        start_position=start_position,
-                        on_complete=lambda: QTimer.singleShot(0, lambda: self.tts_action.setIcon(QIcon("assets/icons/play-circle.svg")))
-                    )
-                except Exception as e:
-                    print("Error during TTS:", e)
-            threading.Thread(target=run_speech).start()
+            try:
+                WW_TTSManager.speak(
+                    text,
+                    start_position=start_position,
+                        on_complete=self.tts_completed
+                )
+            except Exception as e:
+                print("Error during TTS:", e)
 
     def perform_tts(self):
         self.toggle_tts()
+
+    def tts_completed(self):
+        self.tts_playing = False
+        self.tts_action.setIcon(QIcon("assets/icons/play-circle.svg"))
 
     def open_focus_mode(self):
         scene_text = self.editor.toPlainText()

--- a/tts_manager.py
+++ b/tts_manager.py
@@ -1,54 +1,100 @@
 import pyttsx3
 import json, os
+import threading
+import logging
+import platform
+import subprocess
 from settings_manager import WWSettingsManager
 
-def get_tts_rate():
-    """
-    Read the settings.json file and return the desired TTS rate.
-    We'll use 200 as the normal rate and 300 for fast speech.
-    """
-    normal_rate = 200  # Updated normal rate (default speed)
-    fast_rate = 300    # Fast speech remains the same
-    rate = normal_rate
+# Configure logging
+# logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
-    if WWSettingsManager.get_setting("general", "fast_tts"):
-        rate = fast_rate
+class TTSManager:
+    def __init__(self):
+        self._engine = None
+        self._thread = None
+        self.is_mac = platform.system() == "Darwin"
+        logging.debug("TTSManager initialized")
 
-    return rate
+    def get_tts_rate(self):
+        """
+        Read the settings.json file and return the desired TTS rate.
+        We'll use 200 as the normal rate and 300 for fast speech.
+        """
+        normal_rate = 200  # Updated normal rate (default speed)
+        fast_rate = 300    # Fast speech remains the same
+        rate = normal_rate
 
-def get_engine():
-    """
-    Create and return a new pyttsx3 engine instance with the proper rate set.
-    """
-    engine = pyttsx3.init()
-    engine.setProperty("rate", get_tts_rate())
-    return engine
+        if WWSettingsManager.get_setting("general", "fast_tts"):
+            rate = fast_rate
 
-# Global variable to hold the current engine.
-_engine = None
+        logging.debug(f"TTS rate set to {rate}")
+        return rate
 
-def speak(text, start_position=0, on_complete=None):
-    """
-    Create a new engine, speak the text starting from the given cursor location,
-    and then tear it down. Optionally, call on_complete() when done to update
-    the TTS button (or any other UI element) back from "stop".
-    """
-    global _engine
-    _engine = get_engine()
-    # Start speaking from the provided cursor location (start_position)
-    text_to_speak = text[start_position:]
-    _engine.say(text_to_speak)
-    _engine.runAndWait()
-    # Invoke the on_complete callback if provided
-    if on_complete is not None:
-        on_complete()
-    _engine = None
+    def get_engine(self):
+        """
+        Create and return a new pyttsx3 engine instance with the proper rate set.
+        """
+        engine = pyttsx3.init()
+        engine.setProperty("rate", self.get_tts_rate())
+        logging.debug("TTS engine created and rate set")
+        return engine
 
-def stop():
-    """
-    Stop the current speech (if any) and reset the engine.
-    """
-    global _engine
-    if _engine is not None:
-        _engine.stop()
-        _engine = None
+    def speak(self, text, start_position=0, on_complete=None):
+        """
+        Speak the text starting from the given cursor location.
+        On macOS, use the 'say' command. On other OS, use pyttsx3.
+        Optionally, call on_complete() when done to update the TTS button (or any other UI element) back from "stop".
+        """
+        def run_tts():
+            if self.is_mac:
+                logging.debug("Using macOS 'say' command")
+                text_to_speak = text[start_position:]
+                rate = self.get_tts_rate()
+                logging.debug(f"Speaking text: {text_to_speak} at rate: {rate}")
+                subprocess.run(["say", "-r", str(rate), text_to_speak])
+                logging.debug("macOS 'say' command finished")
+            else:
+                logging.debug("Using pyttsx3 TTS engine")
+                self._engine = self.get_engine()
+                # Start speaking from the provided cursor location (start_position)
+                text_to_speak = text[start_position:]
+                logging.debug(f"Speaking text: {text_to_speak}")
+                self._engine.say(text_to_speak)
+                self._engine.runAndWait()
+                logging.debug("pyttsx3 TTS engine finished speaking")
+                self._engine = None
+                logging.debug("TTS engine set to None")
+
+            # Invoke the on_complete callback if provided
+            if on_complete is not None:
+                on_complete()
+
+        # Run the TTS in a separate thread
+        self._thread = threading.Thread(target=run_tts)
+        self._thread.start()
+        logging.debug("TTS thread started")
+
+    def stop(self):
+        """
+        Stop the current speech (if any) and reset the engine.
+        """
+        if self.is_mac:
+            logging.debug("Stopping macOS 'say' command")
+            subprocess.run(["killall", "say"])
+        else:
+            if self._engine is not None:
+                logging.debug("Stopping pyttsx3 TTS engine")
+                self._engine.stop()
+                self._engine = None
+            if self._thread is not None:
+                logging.debug("Joining TTS thread")
+                self._thread.join()
+                self._thread = None
+        logging.debug("TTS engine and thread stopped")
+
+WW_TTSManager = TTSManager()
+
+# Usage example
+if __name__ == "__main__":
+    WW_TTSManager.speak("Hello, this is a test.")


### PR DESCRIPTION
I implemented a workaround for Mac TTS. In the process I rewrote the tts-manager to move the multi-threading inside the class, so it looks like I rewrote a lot but it's actually not that much. Please confirm that this still works on Windows, including pressing the stop button while the audio is still in playback.