### PR TITLE
Bugfix/project editor

### DIFF
--- a/project_ui.py
+++ b/project_ui.py
@@ -72,6 +72,7 @@ def build_main_ui(window):
     window.tree.customContextMenuRequested.connect(window.show_tree_context_menu)
     window.populate_tree()
     window.tree.currentItemChanged.connect(window.tree_item_changed)
+    window.tree.itemSelectionChanged.connect(window.tree_item_selection_changed)
     main_splitter.addWidget(window.tree)
 
     # --- Right Panel: Vertical Splitter ---
@@ -303,7 +304,6 @@ def build_main_ui(window):
     window.stop_button.setIcon(window.get_tinted_icon("assets/icons/x-octagon.svg", tint_color=tint))
     window.stop_button.setToolTip("Stop the LLM processing")
     window.stop_button.clicked.connect(window.stop_llm)
-    window.stop_button.setEnabled(False)
     left_buttons_layout.addWidget(window.stop_button)
     window.context_toggle_button = QPushButton()
     window.context_toggle_button.setIcon(window.get_tinted_icon("assets/icons/book.svg", tint_color=tint))

--- a/project_window_core.py
+++ b/project_window_core.py
@@ -292,19 +292,29 @@ class ProjectWindow(QMainWindow):
         current = self.tree.currentItem()
         
         # Before switching, if there is a previous item, check for unsaved changes.
-        if self.previous_item and self.unsaved_changes:
-            reply = QMessageBox.question(
-                self,
-                "Unsaved Changes",
-                "You have unsaved content in this scene and/or pending prompt output. Do you really want to leave?",
-                QMessageBox.Yes | QMessageBox.No
-            )
-            if reply == QMessageBox.No:
-                self.tree.blockSignals(True)
-                self.tree.setCurrentItem(self.previous_item)
-                self.tree.blockSignals(False)
-                return
+        if self.previous_item:
+            warning_message = None
 
+            if self.preview_text.toPlainText().strip():
+                warning_message = "You have content in the preview text that hasn't been appled."
+
+            if self.unsaved_changes:
+                warning_message = "You have unsaved content on this screen."
+
+            if warning_message:
+                reply = QMessageBox.question(
+                    self,
+                    "Unsaved Changes",
+                    f"{warning_message} Do you really want to leave?",
+                    QMessageBox.Yes | QMessageBox.No
+                )
+
+                if reply == QMessageBox.No:
+                    self.tree.blockSignals(True)
+                    self.tree.setCurrentItem(self.previous_item)
+                    self.tree.blockSignals(False)
+                    return
+                
         self.load_current_item_content()
         self.previous_item = current
         self.unsaved_changes = False  # Clear unsaved changes flag

--- a/project_window_core.py
+++ b/project_window_core.py
@@ -10,7 +10,7 @@ from PyQt5.QtWidgets import (
     QMainWindow, QInputDialog, QMenu, QMessageBox, QApplication, QDialog,
     QFontDialog, QShortcut, QLabel
 )
-from PyQt5.QtCore import Qt, QTimer, QSettings, pyqtSlot, QItemSelectionModel
+from PyQt5.QtCore import Qt, QTimer, QSettings, pyqtSlot
 from PyQt5.QtGui import QFont, QTextCharFormat, QIcon, QKeySequence, QPixmap, QPainter, QColor, QTextCursor
 from compendium import CompendiumWindow
 from workshop import WorkshopWindow
@@ -900,6 +900,7 @@ class ProjectWindow(QMainWindow):
         self.pov_character_combo.addItems(characters)
 
     def on_editor_text_changed(self):
+        self.update_word_count()
         self.unsaved_changes = True
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed 3 things:

1. I found a deadlock that can occur when you send a streaming request and the LLM returns an error. As a quick solution, I have the stop button always unlock the send button. I'll implement a better solution, like when you play TTS and the button changes icon to show it is sending the request, and becomes a stop sign.

2. I fixed the apply button so that it does not convert the editor text into plain text and it just inserts the new generated content to the end of the editor. Need to check if rewrite has a similar problem.

3. I fixed the logic for checking if you have unsaved edits, so that it includes changes to formatting. I also made some changes to the way to cancels the switch to a new scene - it was highlighting the wrong scene.