### PR TITLE
Bugfixes for summaries and project structure loader

### DIFF
--- a/project_window/summary_feature.py
+++ b/project_window/summary_feature.py
@@ -70,7 +70,8 @@ class SummaryCreator:
         # text = ' '.join(word for word in words if word.lower() not in self.stop_words)
         # 3. Simplify punctuation
         text = re.sub(r'[.!?]+', '. ', text)  # Normalize sentence endings
-        text = re.sub(r'[^a-zA-Z0-9\s.]', '', text)  # Remove special chars except periods
+#       Non-ascii characters would choke if we did the next line.
+#        text = re.sub(r'[^a-zA-Z0-9\s.]', '', text)  # Remove special chars except periods
 
         # Check token count (approximate: 1 word ≈ 1.3 tokens)
         tokens = self.encoding.encode(text)
@@ -304,7 +305,7 @@ class SummaryCreator:
             hierarchy.insert(0, temp.text(0).strip())
             temp = temp.parent()
 
-        project_name = self.project_window.model.project_name
+        project_name = WWSettingsManager.sanitize(self.project_window.model.project_name)
         sanitized = [WWSettingsManager.sanitize(x) for x in hierarchy]
         filename = f"{project_name}-Summary-{'-'.join(sanitized)}.txt"
         return WWSettingsManager.get_project_path(project_name, filename)

--- a/project_window/tree_manager.py
+++ b/project_window/tree_manager.py
@@ -9,12 +9,28 @@ from settings.settings_manager import WWSettingsManager
 def get_structure_file_path(project_name, backward_compat=False):
     """Return the path to the project-specific structure file."""
     sanitized = re.sub(r'\s+', '', project_name)
-    path = WWSettingsManager.get_project_path(file=sanitized + '_structure.json')
-    if backward_compat and not os.path.exists(path):
-        oldpath = os.path.join(os.getcwd(), f"{sanitized}_structure.json")
-        if os.path.exists(oldpath):
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            os.rename(oldpath, path)
+    structure_name = sanitized + '_structure.json'
+    path = WWSettingsManager.get_project_path(sanitized, structure_name)
+    if backward_compat:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+        if os.path.exists(path): 
+            oldpath = WWSettingsManager.get_project_path(file=structure_name)
+            if os.path.exists(oldpath):
+                newpath_modtime = os.path.getmtime(path)
+                oldpath_modtime = os.path.getmtime(oldpath)
+                if (oldpath_modtime > newpath_modtime):
+                    os.rename(oldpath, path)
+        else:
+            # check in Projects home
+            oldpath = WWSettingsManager.get_project_path(file=structure_name)
+            if os.path.exists(oldpath):
+                os.rename(oldpath, path)
+            else:
+                # check in cwd
+                oldpath = os.path.join(os.getcwd(), structure_name)
+                if os.path.exists(oldpath):
+                    os.rename(oldpath, path)
     return path
 
 def load_structure(project_name):


### PR DESCRIPTION
The summary generator tries to remove non-ascii characters when it runs out of tokens. This is a problem for non-English languages, so I commented it out.

The Summary save file now removes spaces and other separators from the project name when it save it. This file is never loaded, so having spaces in the file name wasn't a problem. It's just inconsistent.

The project structure loader had a bug where it looks for the project xxx_structure file in the Projects directory instead of in the proper sub-directory. This was only a problem the first time you load your project with the xxx_structure file saved in the cwd() directory. This fix will look to see which xxx_structure file has been most recently modified and make sure it's the one we use.