### PR TITLE
Minor LLM Formatting Improvements

### DIFF
--- a/project_window/bottom_stack.py
+++ b/project_window/bottom_stack.py
@@ -12,6 +12,7 @@ from settings.llm_api_aggregator import WWApiAggregator
 from muse.prompt_preview_dialog import PromptPreviewDialog
 import json
 import os
+import re
 
 class BottomStack(QWidget):
     """Stacked widget for summary and LLM panels."""
@@ -219,6 +220,20 @@ class BottomStack(QWidget):
                     self.summary_model_combo.addItem(prompt["model"])
                 break
 
+    def apply_preview(self):
+        """Appends the LLM's output to the current scene while preserving formatting and structure."""
+        preview_text = self.preview_text.toPlainText()
+
+        # Format Markdown-style bold and italic text as HTML.
+        formatted_preview = re.sub(r"\*\*(.*?)\*\*", r"<b>\1</b>", preview_text)  # Bold
+        formatted_preview = re.sub(r"\*(.*?)\*", r"<i>\1</i>", formatted_preview)  # Italic
+
+        # Replace newlines with <br> to preserve paragraph breaks in HTML.
+        formatted_preview = formatted_preview.replace("\n", "<br>")
+
+        # Append the formatted text to the scene editor.
+        self.controller.scene_editor.editor.insertHtml(f"<p>{formatted_preview}</p>")
+        self.controller.scene_editor.editor.insertHtml("<br>")  # Add a blank line for spacing.
 
     def _load_summary_prompts(self):
         """

--- a/project_window/context_panel.py
+++ b/project_window/context_panel.py
@@ -195,7 +195,7 @@ class ContextPanel(QWidget):
             for j in range(cat_item.childCount()):
                 entry_item = cat_item.child(j)
                 if entry_item.checkState(0) == Qt.Checked:
-                    text = self.compendium_manager.get_text(category, entry_item.text(0), self.project_name)
+                    text = self.compendium_manager.get_text(category, entry_item.text(0))
                     texts.append(f"[Compendium Entry - {category} - {entry_item.text(0)}]:\n{text}")
 
         if texts:

--- a/project_window/project_window.py
+++ b/project_window/project_window.py
@@ -2,6 +2,7 @@ import os
 import time
 import json
 import tiktoken
+import re
 
 from PyQt5.QtWidgets import QMainWindow, QSplitter, QLabel, QShortcut, QMessageBox, QInputDialog, QApplication, QDialog
 from PyQt5.QtCore import Qt, QTimer, QSettings, pyqtSlot
@@ -478,7 +479,7 @@ class ProjectWindow(QMainWindow):
             None
         )
         self.bottom_stack.preview_text.clear()
-        self.bottom_stack.preview_text.setReadOnly(True) # User clicks can really mess up the text inserts
+        self.bottom_stack.psetRe # User clicks can really mess up the text insertsadOnly.setRe # User clicks can really mess up the text insertsadOnly(True) # User clicks can really mess up the text inserts
         self.worker = LLMWorker(final_prompt, self.current_prose_config)
         self.worker.data_received.connect(self.update_text)
         self.worker.finished.connect(self.on_finished)
@@ -506,6 +507,13 @@ class ProjectWindow(QMainWindow):
         self.retry_with_summary(truncated)
 
     def update_text(self, text):
+        # Format Markdown-style bold and italic text as HTML.
+        formatted_text = re.sub(r"\*\*(.*?)\*\*", r"<b>\1</b>", text)  # Bold
+        formatted_text = re.sub(r"\*(.*?)\*", r"<i>\1</i>", formatted_text)  # Italic
+        
+        # Replace newlines with <br> to preserve paragraph breaks in HTML.
+        formatted_text = formatted_text.replace("\n", "<br>")
+        
         cursor = self.bottom_stack.preview_text.textCursor()
         cursor.movePosition(QTextCursor.End)  # Move cursor to the end
         self.bottom_stack.preview_text.setTextCursor(cursor)
@@ -514,12 +522,22 @@ class ProjectWindow(QMainWindow):
     def on_finished(self):
         self.bottom_stack.send_button.setEnabled(True)
         self.bottom_stack.preview_text.setReadOnly(False)
+
         if not self.bottom_stack.preview_text.toPlainText().strip():
             QMessageBox.warning(self, "LLM Response", "The LLM did not return any text. Possible token limit reached or an error occurred.")
+            return
+
+        # Format Markdown-style bold and italic text as HTML.
+        raw_text = self.bottom_stack.preview_text.toPlainText()
+        formatted_text = re.sub(r"\*\*(.*?)\*\*", r"<b>\1</b>", raw_text)  # Bold
+        formatted_text = re.sub(r"\*(.*?)\*", r"<i>\1</i>", formatted_text)  # Italic
         
-        # Connect preview_text modified signal if not already connected
-        if not self.bottom_stack.preview_text.receivers(self.bottom_stack.preview_text.textChanged):
-            self.bottom_stack.preview_text.textChanged.connect(self.on_preview_text_changed)
+        # Replace newlines with <br> to preserve paragraph breaks in HTML.
+        formatted_text = formatted_text.replace("\n", "<br>")
+
+
+        # Set the formatted text in the preview text area.
+        self.bottom_stack.preview_text.setHtml(f"<p>{formatted_text}</p>")
 
     def stop_llm(self):
         if hasattr(self, 'worker') and self.worker.isRunning():
@@ -528,21 +546,39 @@ class ProjectWindow(QMainWindow):
         self.bottom_stack.preview_text.setReadOnly(False)
 
     def apply_preview(self):
+        """Appends the LLM's output to the scene editor."""
         preview = self.bottom_stack.preview_text.toPlainText().strip()
         if not preview:
             QMessageBox.warning(self, "Apply Preview", "No preview text to apply.")
             return
+
+        # Include the prompt block if the checkbox is checked
         prompt_block = ""
         if self.bottom_stack.include_prompt_checkbox.isChecked():
             prompt = self.bottom_stack.prompt_input.toPlainText().strip()
             if prompt:
                 prompt_block = f"\n{'_' * 10}\n{prompt}\n{'_' * 10}\n"
+
+        # Format Markdown-style bold and italic text as HTML
+        formatted_preview = re.sub(r"\*\*(.*?)\*\*", r"<b>\1</b>", preview)  # Bold
+        formatted_preview = re.sub(r"\*(.*?)\*", r"<i>\1</i>", formatted_preview)  # Italic
+
+        # Replace newlines with <br> to preserve paragraph breaks in HTML
+        formatted_preview = formatted_preview.replace("\n", "<br>")
+        
+        # Combine the prompt block and formatted preview
+        combined_content = f"{prompt_block}<p>{formatted_preview}</p>"
+
+        # Append the formatted text and prompt block to the scene editor
         cursor = self.scene_editor.editor.textCursor()
-        cursor.movePosition(QTextCursor.End)
-        cursor.insertText(prompt_block + preview)
-        self.scene_editor.editor.moveCursor(QTextCursor.End)
+        cursor.movePosition(QTextCursor.End)  # Move cursor to the end of the current text
+        self.scene_editor.editor.setTextCursor(cursor)
+        self.scene_editor.editor.insertHtml(combined_content)  # Append the prompt block and preview text
+        self.scene_editor.editor.insertHtml("<br>")  # Add a blank line for spacing
+        self.scene_editor.editor.moveCursor(QTextCursor.End)  # Ensure the cursor is at the end
+
+        # Clear the preview text area after applying
         self.bottom_stack.preview_text.clear()
-        self.bottom_stack.prompt_input.clear()
         self.model.unsaved_changes = True
         self.unsaved_preview = False
 

--- a/start.bat
+++ b/start.bat
@@ -3,11 +3,19 @@ REM ===========================================
 REM Start script for Writingway
 REM ===========================================
 
-REM Activate the virtual environment.
-echo Activating virtual environment...
-call venv\Scripts\activate
+REM Check if virtual environment exists
+if not exist "venv\Scripts\activate.bat" (
+    echo Virtual environment not found. Creating and setting up...
+    python -m venv venv
+    call venv\Scripts\activate.bat
+    echo Installing requirements...
+    pip install -r requirements.txt
+) else (
+    echo Activating existing virtual environment...
+    call venv\Scripts\activate.bat
+)
 
-REM Run the main Python script.
+REM Run the main Python script
 echo Running main.py...
 python main.py
 

--- a/workshop/workshop.py
+++ b/workshop/workshop.py
@@ -260,7 +260,16 @@ class WorkshopWindow(QDialog):
 
             response = WWApiAggregator.send_prompt_to_llm("", overrides=overrides, conversation_history=conversation_payload)
 
-            self.chat_log.append("LLM: " + response)
+            # Format the response to render Markdown-style bold and italic text as HTML.
+            formatted_response = re.sub(r"\*\*(.*?)\*\*", r"<b>\1</b>", response)  # Bold
+            formatted_response = re.sub(r"\*(.*?)\*", r"<i>\1</i>", formatted_response)  # Italic
+
+            # Replace newlines with <br> to preserve paragraph breaks in HTML.
+            formatted_response = formatted_response.replace("\n", "<br>")
+
+            # Append the formatted response to the chat log using insertHtml to preserve structure.
+            self.chat_log.insertHtml(f"<p><b>LLM:</b> {formatted_response}</p>")
+            self.chat_log.insertHtml("<br>")  # Add a blank line for spacing.
             QApplication.processEvents()
 
             self.conversation_history = conversation_payload
@@ -281,7 +290,17 @@ class WorkshopWindow(QDialog):
         for msg in self.conversation_history:
             role = msg.get("role", "Unknown")
             content = msg.get("content", "")
-            self.chat_log.append(f"{role.capitalize()}: {content}")
+
+            # Format Markdown-style bold and italic text as HTML.
+            formatted_content = re.sub(r"\*\*(.*?)\*\*", r"<b>\1</b>", content)  # Bold
+            formatted_content = re.sub(r"\*(.*?)\*", r"<i>\1</i>", formatted_content)  # Italic
+
+            # Replace newlines with <br> to preserve paragraph breaks in HTML.
+            formatted_content = formatted_content.replace("\n", "<br>")
+
+            # Append the formatted content to the chat log.
+            self.chat_log.insertHtml(f"<p><b>{role.capitalize()}:</b> {formatted_content}</p>")
+            self.chat_log.insertHtml("<br>")  # Add a blank line for spacing.
 
     def show_conversation_context_menu(self, pos: QPoint):
         item = self.conversation_list.itemAt(pos)


### PR DESCRIPTION
Changed start.bat to create a venv in the directory and install the requirements so no conflicting packages could cause a problem later for users.

Formatting in workshop chat now includes bolt and italic from the LLM, easier and better readability.

I did the same for LLM preview in project window, but when appending they disappear. 

![{784783BF-B1E5-4FA0-B1E7-62B1CBA7F108}](https://github.com/user-attachments/assets/b1e58b22-8e01-4217-90bf-bd401aa9671c)
