### PR TITLE
Bugfix/scene saver

### DIFF
--- a/project_window/project_structure_manager.py
+++ b/project_window/project_structure_manager.py
@@ -46,7 +46,12 @@ def move_item_up(window, item):
         parent.takeChild(index)
         parent.insertChild(index - 1, item)
         window.project_tree.tree.setCurrentItem(item)
-        tree_manager.update_structure_from_tree(window.project_tree.tree, window.model.project_name)
+        hierarchy = window.get_item_hierarchy(item)
+        uuid = item.data(0, Qt.UserRole)["uuid"]
+
+        window.model.update_structure(window.project_tree.tree)
+#        tree_manager.update_structure_from_tree(window.project_tree.tree, window.model.project_name)
+        window.model.structureChanged.emit(hierarchy, uuid)
 
 def move_item_down(window, item):
     """Move an item down in the tree."""
@@ -56,4 +61,9 @@ def move_item_down(window, item):
         parent.takeChild(index)
         parent.insertChild(index + 1, item)
         window.project_tree.tree.setCurrentItem(item)
-        tree_manager.update_structure_from_tree(window.project_tree.tree, window.model.project_name)
+        hierarchy = window.get_item_hierarchy(item)
+        uuid = item.data(0, Qt.UserRole)["uuid"]
+        window.model.update_structure(window.project_tree.tree)
+#        tree_manager.update_structure_from_tree(window.project_tree.tree, window.model.project_name)
+        window.model.structureChanged.emit(hierarchy, uuid)
+

--- a/settings/autosave_manager.py
+++ b/settings/autosave_manager.py
@@ -76,7 +76,7 @@ def cleanup_old_autosaves(project_folder: str, scene_identifier: str, max_files:
         except Exception as e:
             print("Error removing old autosave file:", e)
 
-def save_scene(project_name: str, hierarchy: list, content: str) -> str:
+def save_scene(project_name: str, hierarchy: list, content: str, expected_project_name: str = None) -> str:
     """
     Save the scene content if it has changed since the last autosave.
     Uses the new HTML format for saving, preserving rich formatting.
@@ -85,6 +85,7 @@ def save_scene(project_name: str, hierarchy: list, content: str) -> str:
         project_name (str): The name of the project.
         hierarchy (list): List of strings representing the scene hierarchy (e.g., [Act, Chapter, Scene]).
         content (str): The scene content to save (HTML formatted).
+        expected_project_name (str, optional): The project name expected by the caller for validation.
     
     Returns:
         The filepath of the new autosave file if saved, or None if no changes were detected.
@@ -100,6 +101,12 @@ def save_scene(project_name: str, hierarchy: list, content: str) -> str:
     timestamp = time.strftime("%Y%m%d%H%M%S")
     filename = f"{scene_identifier}_{timestamp}{NEW_FILE_EXTENSION}"
     filepath = os.path.join(project_folder, filename)
+
+    # Validate project directory if expected_project_name is provided
+    if expected_project_name and expected_project_name != project_name:
+        error_msg = f"Autosave error: Attempted to save content for project '{expected_project_name}' into project '{project_name}' directory at {filepath}"
+        print(error_msg)
+        return None  # Prevent saving to the wrong project
 
     try:
         with open(filepath, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Bugs fixed:

1. The autosave timer will be terminated when you close a project window instead of running as a zombie. I added a error check to ensure that autosave doesn't try to write to the wrong project directory if you open more than one project window. This bug can happen even if you never open two projects windows at the same time.
2. Check for duplicate Act/Chapter/Scene names and prevent the uses from creating them. If the user creates a duplicate name, then the save file names will overlap and they'll see the same content in two scene items with the same name.
3. No more "unsaved content" warning. Now it just saves the scene if you navigate away or close the window. I left a stub function to save the generated preview content, but I think it lingers until you apply it or close the project window. The warning popup causes weird behavior if the user right-clicks to create a new scene (for example), so the best solution is to get rid up the popup window.

This PR also includes the feature I added to show the cover image for the last project you opened when you start Writingway.