### PR TITLE
Google model JSON tag fixed

### DIFF
--- a/settings/llm_api_aggregator.py
+++ b/settings/llm_api_aggregator.py
@@ -265,7 +265,7 @@ class GeminiProvider(LLMProviderBase):
 
     @property
     def model_key(self) -> str:
-        return "name"
+        return "id"
     
     @property
     def use_reverse_sort(self) -> bool:
@@ -275,7 +275,7 @@ class GeminiProvider(LLMProviderBase):
         if not self.llm_instance:
             self.llm_instance = ChatGoogleGenerativeAI(
                 google_api_key=overrides.get("api_key", self.get_api_key()),
-                google_api_base=overrides.get("endpoint", self.get_base_url()),
+#                api_endpoint=overrides.get("endpoint", self.get_base_url()), # Unsupported by Google API
                 model=overrides.get("model", self.get_current_model() or "gemini-2.0-flash"),
                 temperature=overrides.get("temperature", self.config.get("temperature", DEFAULT_TEMPERATURE)),
                 max_output_tokens=overrides.get("max_tokens", self.config.get("max_tokens", DEFAULT_MAX_TOKENS)),


### PR DESCRIPTION
The new model detail pane mapped the google JSON tag "name" to "id", and the display name got mapped to the name. This is a problem when you select a model, because Google expects the id, not the display name, in the prompt request. I fixed it by configuring our model request to use the "id" tag instead of the name.

I also removed "google_api_base", since it never worked and recently Google started printing warnings when we supply unsupported llm parameters.