### PR TITLE
Fix impossible dependency requirements (issue #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,28 +18,32 @@ Writingway is an innovative AI-powered creative writing tool designed to empower
 
 This section provides a step-by-step guide on how to install and run Writingway.  Even if you're new to Python, these instructions should help you get started.
 
+**Prerequisites:**
+
+Python 3.11 is recommended. Python 3.12 and 3.13 are also supported. The setup scripts will attempt to detect a compatible Python version automatically.
+
 **4. Install Writingway (Placeholder):**
 
 Windows users:
 Run setup_writingway.bat
 
 Mac OS users:
-Mac OS requires an audito tool that is not available for install by the Writingway setup script. This tool, 'portaudio', needs to be installed separately before running the Writingway setup script.
+Mac OS requires an audio tool that is not available for install by the Writingway setup script. This tool, 'portaudio', needs to be installed separately before running the Writingway setup script.
 1. Install Homebrew for Mac OS if you haven't already
-2. Run this command: 'brew install portaudito'
+2. Run this command: 'brew install portaudio'
 
 Mac OS/Linux users:
-Execute this commmand in a terminal window from the Wrightingway root directory
+Execute this command in a terminal window from the Writingway root directory
 
-source setup_wrightingway.sh
+bash setup_writingway.sh
 
 **5. Run Writingway:**
 
-Windws users:
+Windows users:
 Double click on the start.bat file to run the program. You can also right click and select Create Shortcut, then move the shortcut to your desktop.
 
 Mac OS/Linux users:
-Execute this commmand in a terminal window from the Wrightingway root directory
+Execute this command in a terminal window from the Writingway root directory
 source start.sh
 
 **Troubleshooting:**
@@ -47,6 +51,7 @@ source start.sh
 - If you encounter any errors during installation, make sure you have a stable internet connection.
 - If `pip` is not recognized, ensure that Python's Scripts directory is added to your system's PATH environment variable. (This is usually done automatically during Python installation if you checked the "Add Python to PATH" option.)
 - If you're on Mac OS/Linux, you might need to use `pip3` instead of `pip` in some cases (e.g., `pip3 install PyQt5 pyttsx3 requests`).
+- On Linux, you may need to install `python3-dev` (or `python3.11-dev`) and `portaudio19-dev` packages for pyaudio to build successfully.
 
 If you still have trouble, please consult the project's issue tracker or support channels for assistance.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 faiss-cpu
-langchain==0.3.27
+langchain>=0.3.27,<1.0
 langchain-core
 langchain-openai
 langchain-anthropic
@@ -7,13 +7,13 @@ langchain-google-genai
 langchain-ollama
 langchain-community
 langchain-together
-numpy==1.24.0
-pydantic==2.9.2
+numpy>=1.24.0,<2.0
+pydantic>=2.9.2,<3.0
 PyQt5>=5.15.0
 PyQtChart>=5.15.0
-pyttsx3==2.90
-requests==2.31.0
-spacy==3.7.5
+pyttsx3>=2.90
+requests>=2.31.0,<3.0
+spacy>=3.7.5,<3.9
 textstat
 tiktoken
 noisereduce

--- a/setup_writingway.sh
+++ b/setup_writingway.sh
@@ -1,14 +1,54 @@
 #!/bin/bash
 # ===========================================
-# Setup script for Writingway (macOS)
+# Setup script for Writingway (macOS/Linux)
 # ===========================================
+
+# -------------------------------------------------
+# Detect a suitable Python version (prefer 3.11)
+# -------------------------------------------------
+PYTHON_CMD=""
+
+# Try python3.11 first (best compatibility)
+if command -v python3.11 >/dev/null 2>&1; then
+  PYTHON_CMD="python3.11"
+# Try python3.12
+elif command -v python3.12 >/dev/null 2>&1; then
+  PYTHON_CMD="python3.12"
+# Try python3.13
+elif command -v python3.13 >/dev/null 2>&1; then
+  PYTHON_CMD="python3.13"
+# Fallback to generic python3 and check version
+elif command -v python3 >/dev/null 2>&1; then
+  PY_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
+  case "$PY_VER" in
+    3.11|3.12|3.13) PYTHON_CMD="python3" ;;
+  esac
+fi
+
+if [ -z "$PYTHON_CMD" ]; then
+  echo "ERROR: Python 3.11, 3.12, or 3.13 is required but was not found."
+  echo "Please install Python 3.11 (recommended) from https://www.python.org/downloads/"
+  exit 1
+fi
+
+PY_VERSION=$($PYTHON_CMD --version 2>&1)
+echo "Using $PY_VERSION ($PYTHON_CMD)"
 
 # Check if the virtual environment folder exists.
 if [ ! -d "venv" ]; then
   echo "Creating virtual environment..."
-  python -m venv venv
+  $PYTHON_CMD -m venv venv
 else
   echo "Virtual environment already exists."
+  # Verify the venv Python version is acceptable
+  VENV_VER=$(venv/bin/python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
+  case "$VENV_VER" in
+    3.11|3.12|3.13) ;;
+    *)
+      echo "WARNING: Existing venv uses Python $VENV_VER which may not be compatible."
+      echo "Consider deleting the venv folder and rerunning this script."
+      ;;
+  esac
 fi
 
 # Activate the virtual environment.


### PR DESCRIPTION
## Summary

Fixes #115. The exact version pins in `requirements.txt` made it impossible to resolve dependencies on Python 3.12+, and the shell setup script did not enforce any Python version (unlike the batch file).

- **`requirements.txt`**: Replaced exact version pins (`==`) with compatible ranges (`>=x,<y`) for `numpy`, `spacy`, `langchain`, `pydantic`, `requests`, and `pyttsx3`. This allows pip to resolve a working dependency set across Python 3.11-3.13. The key blocker was `numpy==1.24.0` which has no wheels for Python 3.12+ and fails to build from source.
- **`setup_writingway.sh`**: Added Python version detection that prefers 3.11, falls back to 3.12/3.13, and exits with a clear error if no compatible version is found. Also validates existing venvs and warns if they use an incompatible Python. This brings the shell script in line with `setup_writingway.bat` which already enforces Python 3.11.
- **`README.md`**: Fixed several typos (`portaudito` -> `portaudio`, `Wrightingway` -> `Writingway`, `commmand` -> `command`, `Windws` -> `Windows`), changed `source setup_writingway.sh` to `bash setup_writingway.sh` for broader shell compatibility, added Python version prerequisites section, and added a Linux troubleshooting tip for pyaudio build deps (`python3-dev`, `portaudio19-dev`).

## Test plan

- [ ] Run `pip install -r requirements.txt` in a Python 3.11 venv and verify all packages install
- [ ] Run `pip install -r requirements.txt` in a Python 3.12 or 3.13 venv and verify all packages install
- [ ] Run `bash setup_writingway.sh` on macOS/Linux and verify it detects the correct Python version
- [ ] Run `python main.py` after setup and verify the application starts correctly

*This PR was created with the assistance of Claude by Anthropic. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).