### PR TITLE
Fix: Error adding image to a compendium item

### DIFF
--- a/compendium/enhanced_compendium.py
+++ b/compendium/enhanced_compendium.py
@@ -790,7 +790,7 @@ class EnhancedCompendiumWindow(QMainWindow):
 
     def add_image(self):
         """Add an image to the current entry."""
-        file_name, _ = QFileDialog.getOpenFileName(self, _("Select Image"), "", _("Images (*.png *.jpg *.jpeg *.bmp)"))
+        file_name, _unused = QFileDialog.getOpenFileName(self, _("Select Image"), "", _("Images (*.png *.jpg *.jpeg *.bmp)"))
         if file_name and hasattr(self, 'current_entry'):
             pixmap = QPixmap(file_name)
             if not pixmap.isNull():


### PR DESCRIPTION
Fixes:

```
UnboundLocalError: cannot access local variable '_' where it is not associated with a value Traceback (most recent call last):
  File "Writingway/compendium/enhanced_compendium.py", line 793, in add_image
    file_name, _ = QFileDialog.getOpenFileName(self, _("Select Image"), "", _("Images (*.png *.jpg *.jpeg *.bmp)"))
 ```