### PR TITLE
Update OSX build GitHub workflow to the new node24 runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Let Dependabot create PRs for GitHub Actions used in workflows to keep them up to date.
+  - package-ecosystem: "github-actions"
+    # Look for workflow files in .github/workflows
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/build-osx-arm64.yml
+++ b/.github/workflows/build-osx-arm64.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       
     # Install macports to get portaudio
     - name: Setup MacPorts (macOS)

--- a/.github/workflows/build-osx-arm64.yml
+++ b/.github/workflows/build-osx-arm64.yml
@@ -8,6 +8,11 @@ on:
     tags:
       - '*'
 
+env:
+  # Opt in to the new GitHub Action node24 runners that will be
+  # the default from June 2nd, 2026
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/build-osx-arm64.yml
+++ b/.github/workflows/build-osx-arm64.yml
@@ -34,7 +34,7 @@ jobs:
         exit 1
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version-file: '.python-version'
 

--- a/.github/workflows/build-osx-arm64.yml
+++ b/.github/workflows/build-osx-arm64.yml
@@ -133,7 +133,7 @@ jobs:
         cd ..
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.release_info.outputs.tag_name }}
         name: ${{ steps.release_info.outputs.release_name }}


### PR DESCRIPTION
GitHub is updating the runners to node24, the old ones will stop working in June. Update the workflow and switch to the new runner now.
Add a dependabot config that notifies when an update of an action in the workfow(s) is available